### PR TITLE
Replace build caching with envkey-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 envkey-heroku-buildpack
 =======================
 
-A buildpack for loading EnvKey variables before the main buildpack's compilation phase. Useful if you need some of you EnvKey config to be set during compilation--for example, when using NPM private modules, an NPM_TOKEN is required to install dependencies.
+A buildpack for loading EnvKey variables before the main buildpack's compilation phase. Useful if you need some of you EnvKey config to be set during compilation--for example, when using NPM private modules, an NPM_TOKEN is required to install dependencies. Additionally, `envkey-source` is invoked via `.profile.d` whenever the application restarts.
 
 Requires that a valid ENVKEY is set as a heroku config var.
 

--- a/bin/compile
+++ b/bin/compile
@@ -19,19 +19,16 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo "Downloading envkey-source ${ENVKEY_VERSION} from ${ENVKEY_URL}" | indent
   curl -s -L -o envkey-source.tar.gz "${ENVKEY_URL}"
   tar zxf envkey-source.tar.gz envkey-source
+  rm envkey-source.tar.gz
+  mv envkey-source $BUILD_DIR/bin
 
   echo "ENVKEY config var is set" | indent
   export "ENVKEY=$(cat $ENV_DIR/ENVKEY)"
-  echo $(./envkey-source) > $BP_DIR/export
+  echo $($BUILD_DIR/bin/envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
-  mkdir $BUILD_DIR/.profile.d
-  cat > $BUILD_DIR/.profile.d/envkey.sh << EOF
-export -p > ./envkey-heroku-runtime-env.sh
-$(cat $BP_DIR/export)
-. ./envkey-heroku-runtime-env.sh
-rm envkey-heroku-runtime-env.sh
-EOF
-  echo "EnvKey variables exported to running application via .profile.d/envkey.sh" | indent
+  mkdir -p $BUILD_DIR/.profile.d
+  echo "eval \$(~/bin/envkey-source)" > $BUILD_DIR/.profile.d/envkey.sh
+  echo "EnvKey will load variables on restart via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent
   exit 1


### PR DESCRIPTION
By default, [envkey-heroku-buildpack](https://github.com/envkey/envkey-heroku-buildpack) hard-codes environment variables as of the time of the build into `.profile.d` ([see related Heroku docs](https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts)).  These environment variables are then injected into the environment any time the application restarts.  This is undesirable as it **requires the application to be rebuilt in order to rotate keys.**

Rather than relying on hard-coded values, these changes instead call `envkey-source` via `.profile.d`, which has the effect of fetching the relevant environment variables on application restart. Note that any environment variables set directly within Heroku will prevail, which is consistent with Envkey's approach, broadly.