### PR TITLE
Ignore .env file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ if [ -f $ENV_DIR/ENVKEY ]; then
   echo $($BUILD_DIR/bin/envkey-source) > $BP_DIR/export
   echo "EnvKey variables exported to subsequent buildpacks" | indent
   mkdir -p $BUILD_DIR/.profile.d
-  echo "eval \$(~/bin/envkey-source)" > $BUILD_DIR/.profile.d/envkey.sh
+  echo "eval \$(~/bin/envkey-source --env-file '.no-env')" > $BUILD_DIR/.profile.d/envkey.sh
   echo "EnvKey will load variables on restart via .profile.d/envkey.sh" | indent
 else
   echo "ENVKEY config var not set" | indent


### PR DESCRIPTION
By default, `envkey-source` loads environment variables from `.env`, if the file exists.  Any values in `.env` then take priority over the values intended to be loaded from envkey.  As we do not use `.env` files in production, these changes ensure no variables will unintentionally be loaded from `.env`.